### PR TITLE
Pull Request for Issue #74.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -35,14 +35,14 @@ if [ "$mode" = "local" ]; then
   params+=' --with-extension-dir=$(datarootdir)/gnome-shell/extensions/$(uuid)'
   params+=' --with-locale-dir=$(extensiondir)/locale'
   params+=' --with-schema-dir=$(extensiondir)/schemas'
-  params+=' --with-icon-dir=$(extensiondir)/icons'
+  params+=' --with-icon-dir=$(extensiondir)/icons/hicolor/scalable/status'
 else
   echo "*** NOTE: machine wide installation will be configured." >&2
   params='--prefix=/usr'
   params+=' --with-extension-dir=$(datarootdir)/gnome-shell/extensions/$(uuid)'
   params+=' --with-locale-dir=$(datarootdir)/locale'
   params+=' --with-schema-dir=$(datarootdir)glib-2.0/schemas'
-  params+=' --with-icon-dir=$(datarootdir)/icons'
+  params+=' --with-icon-dir=$(datarootdir)/icons/hicolor/scalable/status'
 fi
 
 autoreconf --verbose --force --install || exit 1

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,6 +1,6 @@
 # extensiondir declared in configure.ac
-nodist_extension_DATA = metadata.json
-dist_extension_DATA = metadata.json.in
+extension_DATA = metadata.json
+EXTRA_DIST = metadata.json.in
 
 metadata.json: metadata.json.in $(top_builddir)/config.status
 	$(AM_V_GEN) sed -e "s|[@]LOCALEDIR@|$(localedir)|" \
@@ -11,9 +11,7 @@ metadata.json: metadata.json.in $(top_builddir)/config.status
 CLEANFILES = metadata.json
 
 # icondir declared in configure.ac
-iconsubdir = $(icondir)/hicolor/scalable/status
-
-iconsub_DATA = \
+dist_icon_DATA = \
 	sensors-fan-symbolic.svg \
 	sensors-temperature-symbolic.svg \
 	sensors-voltage-symbolic.svg
@@ -22,4 +20,4 @@ gsettings_SCHEMAS = org.gnome.shell.extensions.sensors.gschema.xml
 
 @GSETTINGS_RULES@
 
-EXTRA_DIST = $(gsettings_SCHEMAS)
+EXTRA_DIST += $(gsettings_SCHEMAS)


### PR DESCRIPTION
Re-instated EXTRA_DIST as this was correct for the "input" file metadata.json.in
Removed the "nodist_" prefix on extension_DATA as that is redundant
Added "dist_" prefix to icon_DATA so that it will be installed and distributed
Added the "+" back in to the second EXTRA_DIST setting to include schemas

I tried to run make distcheck, and initially had problems with the icons
```
make[3]: Entering directory '/mnt/my_data/programming/sensors/gnome-shell-extension-sensors/gnome-shell-extension-sensors-2.0/_build/sub/data'
make[3]: Nothing to be done for 'install-exec-am'.
 /usr/bin/mkdir -p '/hicolor/scalable/status'
/usr/bin/mkdir: cannot create directory ‘/hicolor’: Permission denied
make[3]: *** [Makefile:331: install-dist_iconsubDATA] Error 1
make[3]: Leaving directory '/mnt/my_data/programming/sensors/gnome-shell-extension-sensors/gnome-shell-extension-sensors-2.0/_build/sub/data'
```
It seems that distcheck doesn't have the parameters set by autogen.sh, so when the Makefile.am has
```
# icondir declared in configure.ac
iconsubdir = $(icondir)/hicolor/scalable/status
```

the $(icondir) set in configure.ac is blank and therefore it tried to created the directory "/hicolor/..." ie from root dir instead of as a sub dir of the build directory

I worked around this by moving the subdirectories out to autogen.sh, but then make distcheck failed on the schemas
```
make[3]: Entering directory '/mnt/my_data/programming/sensors/gnome-shell-extension-sensors/gnome-shell-extension-sensors-2.0/_build/sub/data'
make[3]: Nothing to be done for 'install-exec-am'.
if test -n "../../../data/org.gnome.shell.extensions.sensors.gschema.xml"; then \
	test -z "" || /usr/bin/mkdir -p ""; \
	/usr/bin/install -c -m 644 ../../../data/org.gnome.shell.extensions.sensors.gschema.xml ""; \
	test -n "" || /usr/bin/glib-compile-schemas ; \
fi
/usr/bin/install: target '' is not a directory: No such file or directory
You should give exactly one directory name
make[3]: *** [Makefile:554: install-gsettings-schemas] Error 1
```
again because gsettingsschemadir is not set.

I'll have to leave that to another day, as getting distcheck working is not a priority. I just ran it out of curiosity.

Need to figure out why the parameters configured by autogen are not passed into distcheck
